### PR TITLE
Implement GCI15 website setup assistant

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,6 +11,10 @@
   background-color: #9E9E9E;
 }
 
+.mdl-textfield {
+  width: 100%;
+}
+
 header .mdl-layout__header-row {
   width: 100%;
   height: 300px;
@@ -30,4 +34,23 @@ header .mdl-layout__header-row {
 
 main {
   margin: 30px auto;
+}
+
+#gci-website-statuses .material-icons {
+  vertical-align: middle;
+}
+
+#gci-website-statuses span span:last-child {
+  font-weight: bold;
+}
+
+.gci-website__status {
+}
+
+.gci-website__status-yes {
+  color: #4CAF50;
+}
+
+.gci-website__status-no {
+  color: #F44336;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -44,13 +44,15 @@ main {
   font-weight: bold;
 }
 
-.gci-website__status {
-}
-
 .gci-website__status-yes {
   color: #4CAF50;
 }
 
 .gci-website__status-no {
+  color: #F44336;
+}
+
+#gci-website__error {
+  font-size: 12px;
   color: #F44336;
 }

--- a/fossasia-gci-website.js
+++ b/fossasia-gci-website.js
@@ -1,0 +1,209 @@
+// This module helps setting up FOSSASIA's GCI15 website repo
+// Also checks if origin and upstream remotes are configured correctly
+
+const git = require('./git');
+const Git = require('nodegit');
+const fs = require('fs');
+const ipcRenderer = require('electron').ipcRenderer;
+
+const gciWebButton = document.querySelector('#gci-website__button');
+gciWebButton.mode = 'clone';
+gciWebButton.innerHTML = 'Clone';
+
+const pathField = document.querySelector('#clone-path');
+
+pathField.value = __dirname;
+updateStatuses(); // Update the statuses for the default value of the path
+
+function updateStatuses() {
+  const path = pathField.value;
+
+  // Set default submit button's values
+  gciWebButton.mode = 'clone';
+  gciWebButton.innerHTML = 'Clone';
+
+  const statusDirIcon = document.querySelectorAll('#gci-website__status-dir > span')[0];
+  const statusDirText = document.querySelectorAll('#gci-website__status-dir > span')[1];
+  const statusRepoIcon = document.querySelectorAll('#gci-website__status-repo > span')[0];
+  const statusRepoText = document.querySelectorAll('#gci-website__status-repo > span')[1];
+  const statusUpstreamIcon = document.querySelectorAll('#gci-website__status-upstream > span')[0];
+  const statusUpstreamText = document.querySelectorAll('#gci-website__status-upstream > span')[1];
+  const statusOriginIcon = document.querySelectorAll('#gci-website__status-origin > span')[0];
+  const statusOriginText = document.querySelectorAll('#gci-website__status-origin > span')[1];
+
+  // Set all statuses as 'no' by default
+  statusDirIcon.className = 'material-icons gci-website__status-no';
+  statusDirIcon.innerHTML = 'clear';
+  statusDirText.className = 'gci-website__status gci-website__status-no';
+  statusDirText.innerHTML = 'doesn\'t exist';
+  statusRepoIcon.className = 'material-icons gci-website__status-no';
+  statusRepoIcon.innerHTML = 'clear';
+  statusRepoText.className = 'gci-website__status gci-website__status-no';
+  statusRepoText.innerHTML = 'isn\'t';
+  statusUpstreamIcon.className = 'material-icons gci-website__status-no';
+  statusUpstreamIcon.innerHTML = 'clear';
+  statusUpstreamText.className = 'gci-website__status gci-website__status-no';
+  statusUpstreamText.innerHTML = 'isn\'t';
+  statusOriginIcon.className = 'material-icons gci-website__status-no';
+  statusOriginIcon.innerHTML = 'clear';
+  statusOriginText.className = 'gci-website__status gci-website__status-no';
+  statusOriginText.innerHTML = 'isn\'t';
+
+  fs.stat(path, function(err, stat) {
+    if(err === null) {  // Path already exists
+      statusDirIcon.className = 'material-icons gci-website__status-yes';
+      statusDirIcon.innerHTML = 'done';
+      statusDirText.className = 'gci-website__status gci-website__status-yes';
+      statusDirText.innerHTML = 'exists';
+      Git.Repository.open(path)
+      .then(function(repo) {
+        repo.getCommit('03850094869f142934e924a3cbb294993f005d44') // Verify this is gci15.fossasia.org, and not any other git repository (that's the very first commit on gh-pages)
+        .then(function(commit) {
+          gciWebButton.mode = 'remote';
+          statusRepoIcon.className = 'material-icons gci-website__status-yes';
+          statusRepoIcon.innerHTML = 'done';
+          statusRepoText.className = 'gci-website__status gci-website__status-yes';
+          statusRepoText.innerHTML = 'is';
+          repo.getRemote('upstream')
+          .then(function(remote) {
+            if(remote.url() === 'https://github.com/fossasia/gci15.fossasia.org.git') { // "upstream" is set to FOSSASIA's repo
+              gciWebButton.mode += '-origin';
+              statusUpstreamIcon.className = 'material-icons gci-website__status-yes';
+              statusUpstreamIcon.innerHTML = 'done';
+              statusUpstreamText.className = 'gci-website__status gci-website__status-yes';
+              statusUpstreamText.innerHTML = 'is';
+              Git.Remote.create(repo, 'upstream', 'https://github.com/fossasia/gci15.fossasia.org.git');
+            }
+            repo.getRemote('origin')
+            .then(function(remote) {
+              if(remote.url() !== 'https://github.com/fossasia/gci15.fossasia.org.git') { // "origin" is set to a custom repo
+                gciWebButton.mode += '-upstream';
+                statusOriginIcon.className = 'material-icons gci-website__status-yes';
+                statusOriginIcon.innerHTML = 'done';
+                statusOriginText.className = 'gci-website__status gci-website__status-yes';
+                statusOriginText.innerHTML = 'is';
+              }
+              switch(gciWebButton.mode) {
+                // Everything is properly configured
+                case 'remote-upstream-origin':
+                case 'remote-origin-upstream':
+                  gciWebButton.disabled = true;
+                  gciWebButton.innerHTML = 'All set!';
+                  break;
+                // Either "upstream" or none of the remotes aren't configured
+                case 'remote':
+                case 'remote-upstream':
+                  gciWebButton.innerHTML = 'Configure "upstream"';
+                  break;
+                // The remote "origin" isn't correctly configured
+                case 'remote-origin':
+                  gciWebButton.innerHTML = 'Configure "origin"';
+                  break;
+              }
+            });
+          });
+        });
+    });
+  } else if(err.code !== 'ENOENT') {  // Something went wrong (excluding path not found)
+      console.log(err);
+    }
+  });
+}
+
+pathField.onclick = function(e) {
+  e.preventDefault();
+
+  // Set up dialog for opening repo's path
+  const options = {
+    title: 'Choose the directory where open/save the repo',
+    properties: [ 'openDirectory' ]
+  };
+
+  // Got the path from the dialog
+  ipcRenderer.on('openDialogReply', function(event, paths) {
+    if(paths !== null) {  // Check the dialog hasn't been cancelled
+      // Set the chosen path as pathField's value
+      pathField.value = paths[0];
+      // Update the statuses (changing the value won't trigger pathfield's oninput
+      // event)
+      updateStatuses();
+    }
+  });
+
+  // Display the dialog
+  ipcRenderer.send('openDialog', options);
+}
+
+pathField.oninput = function(e) {
+  e.preventDefault();
+
+  updateStatuses();
+}
+
+gciWebButton.onclick = function(e) {
+  e.preventDefault();
+
+  const path = pathField.value;
+
+  switch(gciWebButton.mode) {
+    // Either "upstream" or none of the remotes aren't configured
+    case 'remote':
+    case 'remote-upstream':
+      gciWebButton.disabled = true;
+      gciWebButton.style.cursor = 'not-allowed';
+      gciWebButton.innerHTML = 'Loading...';
+
+      document.querySelector('#gci-website__loading').className += ' is-active'; // Display the loading spinner
+
+      Git.Repository.open(path)
+      .then(function(repo) {
+        Git.Remote.create(repo, 'upstream', 'https://github.com/fossasia/gci15.fossasia.org.git');
+        gciWebButton.innerHTML = 'Done!';
+        updateStatuses();
+        document.querySelector('#gci-website__loading').className = 'mdl-spinner mdl-spinner--single-color mdl-js-spinner';  // Hide the loading spinner (by removing the 'is-active' class)
+        setTimeout(function() { // Keep the button disabled with the "Done!" message for a moment
+          gciWebButton.disabled = false;
+          gciWebButton.style.cursor = 'default';
+          gciWebButton.innerHTML = 'Clone';
+        }, 1500);
+      });
+      break;
+
+    // The remote "origin" isn't correctly configured
+    case 'remote-origin':
+      // TO IMPLEMENT WITH USER'S USERNAME, ONCE #9 IS MERGED
+      /*
+      Git.Repository.open(path)
+      .then(function(repo) {
+          Git.Remote.create(repo, 'upstream', customRemote);
+      });
+      */
+      break;
+
+    // The repo isn't cloned yet
+    default:
+      gciWebButton.disabled = true;
+      gciWebButton.style.cursor = 'not-allowed';
+      gciWebButton.innerHTML = 'Loading...';
+
+      document.querySelector('#gci-website__loading').className += ' is-active'; // Display the loading spinner
+
+      Git.Clone.clone('https://github.com/fossasia/gci15.fossasia.org.git', path, null)
+      .then(function(repo, err) {
+        if(err) { // Something went wrong
+          console.log(err);
+          gciWebButton.innerHTML = 'Error!';
+        } else {
+          Git.Remote.create(repo, 'upstream', 'https://github.com/fossasia/gci15.fossasia.org.git');
+          gciWebButton.innerHTML = 'Done!';
+        }
+        updateStatuses();
+        document.querySelector('#gci-website__loading').className = 'mdl-spinner mdl-spinner--single-color mdl-js-spinner';  // Hide the loading spinner (by removing the 'is-active' class)
+        setTimeout(function() { // Keep the button disabled with the "Done!" message for a moment
+          gciWebButton.disabled = false;
+          gciWebButton.style.cursor = 'default';
+          gciWebButton.innerHTML = 'Clone';
+        }, 1500);
+      });
+  }
+}

--- a/fossasia-gci-website.js
+++ b/fossasia-gci-website.js
@@ -66,7 +66,7 @@ function updateStatuses() {
           statusRepoText.innerHTML = 'is';
           repo.getRemote('upstream')
           .then(function(remote) {
-            if(remote.url() === 'https://github.com/fossasia/gci15.fossasia.org.git') { // "upstream" is set to FOSSASIA's repo
+            if(remote.url() === 'https://github.com/fossasia/gci15.fossasia.org.git' || remote.url() === 'https://github.com/fossasia/gci15.fossasia.org') { // "upstream" is set to FOSSASIA's repo
               gciWebButton.mode += '-origin';
               statusUpstreamIcon.className = 'material-icons gci-website__status-yes';
               statusUpstreamIcon.innerHTML = 'done';
@@ -76,7 +76,7 @@ function updateStatuses() {
             }
             repo.getRemote('origin')
             .then(function(remote) {
-              if(remote.url() !== 'https://github.com/fossasia/gci15.fossasia.org.git') { // "origin" is set to a custom repo
+              if(remote.url() !== 'https://github.com/fossasia/gci15.fossasia.org.git' && remote.url() !== 'https://github.com/fossasia/gci15.fossasia.org') { // "origin" is set to a custom repo
                 gciWebButton.mode += '-upstream';
                 statusOriginIcon.className = 'material-icons gci-website__status-yes';
                 statusOriginIcon.innerHTML = 'done';

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       </div>
       <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
         <a href="#scroll-tab-1" class="mdl-layout__tab is-active">Global Git Config</a>
+        <a href="#scroll-tab-2" class="mdl-layout__tab">FOSSASIA GCI Website</a>
       </div>
     </header>
     <main class="mdl-layout__content">
@@ -43,10 +44,48 @@
           </div>
         </div>
       </section>
+      <section class="mdl-layout__tab-panel" id="scroll-tab-2">
+        <div class="page-content">
+          <div class="mdl-card mdl-card-wide mdl-shadow--2dp">
+            <div class="mdl-card__title mdl-card--expand" >
+              <h2 class="mdl-card__title-text">Clone CGI15 Website</h2>
+            </div>
+            <div class="mdl-card__supporting-text">
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                <input id="clone-path" class="mdl-textfield__input" type="text" value="./">
+                <label class="mdl-textfield__label" for="clone-path">Repo path:</label>
+              </div>
+              <div id="gci-website-statuses">
+                <span id="gci-website__status-dir">
+                  <span class="material-icons gci-website__status-icon gci-website__status-no">clear</span>
+                  Specified directory <span class="gci-website__status-no"></span>.
+                </span><br>
+                <span id="gci-website__status-repo">
+                  <span class="material-icons gci-website__status-icon gci-website__status-no">clear</span>
+                  Repo <span class="gci-website__status-no"></span> cloned.
+                </span><br>
+                <span id="gci-website__status-upstream">
+                  <span class="material-icons gci-website__status-icon gci-website__status-no">clear</span>
+                  Remote "upstream" <span class="gci-website__status-no"></span> correctly configured.
+                </span><br>
+                <span id="gci-website__status-origin">
+                  <span class="material-icons gci-website__status-icon gci-website__status-no">clear</span>
+                  Remote "origin" <span class="gci-website__status-no"></span> set to a custom repo.
+                </span>
+              </div>
+          </div>
+          <div class="mdl-card__actions mdl-card--border">
+            <button id="gci-website__button" class="mdl-button mdl-js-button mdl-js-ripple-effect">Clone</button>
+            <div id="gci-website__loading" class="mdl-spinner mdl-spinner--single-color mdl-js-spinner"></div>
+          </div>
+        </div>
+      </div>
+      </section>
     </main>
   </div>
 </body>
 <script>
 require("./git-config.js");
+require("./fossasia-gci-website.js");
 </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
           </div>
           <div class="mdl-card__actions mdl-card--border">
             <button id="gci-website__button" class="mdl-button mdl-js-button mdl-js-ripple-effect">Clone</button>
+            <span id="gci-website__error"></span>
             <div id="gci-website__loading" class="mdl-spinner mdl-spinner--single-color mdl-js-spinner"></div>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 'use strict';
 const electron = require('electron');
-const Git = require('nodegit')
+const ipcMain = require('electron').ipcMain;
+const dialog = require('electron').dialog;
+const Git = require('nodegit');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 
@@ -21,5 +23,14 @@ app.on('ready', function() {
 
   mainWindow.on('closed', function() {
     mainWindow = null;
+  });
+});
+
+// Show a "open file/directory" dialog in the main window, with the options
+// provided in the .send call
+// (see http://goo.gl/56QIxx for details on the possible settings)
+ipcMain.on('openDialog', function(event, options) {
+  dialog.showOpenDialog(options, function(paths) {
+    event.sender.send('openDialogReply', paths);
   });
 });


### PR DESCRIPTION
With this PR, a new tab is added in the UI, that guides the user to successfully configure [FOSSASIA's GCI15 website repo](https://github.com/fossasia/gci15.fossasia.org). This includes cloning the repo, and checking if it has correctly configured the remotes `upstream` and `origin`.
This should fullfill #2.
# Screenshot

![Google Code-In Companion Screenshot](https://cloud.githubusercontent.com/assets/7356565/12216910/f9a604d6-b6f0-11e5-8a63-3f2940e0e521.png)
# Known bugs
- The button with ID `gci-website__button` doesn't update its `innerHTML` with the corresponding action properly
- Clicking the button to configure the remote `origin` won't work (stays on hold until #9 is merged, so the assistant can automatically set the remote as `https://github.com/<username>/gci15.fossasia.org`)
